### PR TITLE
fix(bbolt): return special error if bucket doesn't exist

### DIFF
--- a/bbolt/client.go
+++ b/bbolt/client.go
@@ -32,7 +32,7 @@ func (p bboltStorage) Get(ctx context.Context, k string) (r string, err error) {
 	err = p.db.View(func(tx *bbolt.Tx) error {
 		bucket := tx.Bucket(p.bucket)
 		if bucket == nil {
-			return errors.Errorf("bucket %q does not exist", p.bucket)
+			return kv.ErrKeyNotFound
 		}
 
 		result := bucket.Get([]byte(k))


### PR DESCRIPTION
Bbolt storage creates bucket automatically (`bbolt/client.go line 19`) if it doesn't exist
``` go
bucket, err := tx.CreateBucketIfNotExists(p.bucket)
```

So I don't see a point in returning a non-special error if bucket doesn't exist